### PR TITLE
feat: add SRAMs, enable antenna check

### DIFF
--- a/cocotb/chip_top_tb.py
+++ b/cocotb/chip_top_tb.py
@@ -76,7 +76,7 @@ async def test_counter(dut):
     await ClockCycles(dut.clk_PAD, 100)
 
     # Check the end result of the counter
-    assert dut.bidir_PAD.value == 100 - 1
+    assert dut.output_PAD.value == 100 - 1
 
     logger.info("Done!")
 
@@ -105,9 +105,13 @@ def chip_top_runner():
         # IO pad models
         Path(pdk_root) / pdk / "libs.ref/sg13g2_io/verilog/sg13g2_io.v",
         
-        # Bondpad
+        # Bondpads
         proj_path / "../ip/bondpad_70x70/vh/bondpad_70x70.v",
         proj_path / "../ip/bondpad_70x70_novias/vh/bondpad_70x70_novias.v",
+        
+        # SRAM models
+        Path(pdk_root) / pdk / "libs.ref/sg13g2_sram/verilog/RM_IHPSG13_1P_1024x32_c2_bm_bist.v",
+        Path(pdk_root) / pdk / "libs.ref/sg13g2_sram/verilog/RM_IHPSG13_1P_core_behavioral_bm_bist.v",
     ]
 
     build_args = []

--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         "nix-eda": "nix-eda"
       },
       "locked": {
-        "lastModified": 1768309154,
-        "narHash": "sha256-8jB6dO01fs+znaHM+dOOeIICncGnnHz9opq1X/q4h0w=",
+        "lastModified": 1768751929,
+        "narHash": "sha256-mGIccAlvSOVuoes7wAAokx8dlC79nosnCPYqV2S0Z5E=",
         "owner": "librelane",
         "repo": "librelane",
-        "rev": "e497957a219525a574eb60d369879c5601443991",
+        "rev": "71b56d6b998129a44915d2f351b212736f5748c1",
         "type": "github"
       },
       "original": {

--- a/librelane/config.yaml
+++ b/librelane/config.yaml
@@ -15,8 +15,8 @@ meta:
     #Checker.MagicDRC: null
 
     # Disable KLayout antenna check
-    KLayout.Antenna: null
-    Checker.KLayoutAntenna: null
+    #KLayout.Antenna: null
+    #Checker.KLayoutAntenna: null
 
     # Disable KLayout density check
     #KLayout.Density: null
@@ -33,8 +33,11 @@ VERILOG_FILES:
 - dir::../src/chip_top.sv
 - dir::../src/chip_core.sv
 
+VERILOG_DEFINES: [FUNCTIONAL]
+
 # Enable plugin for better SystemVerilog support
 # USE_SLANG: True
+# SLANG_ARGUMENTS: ['--keep-hierarchy']
 
 # Slightly smaller file sizes
 PRIMARY_GDSII_STREAMOUT_TOOL: klayout
@@ -147,16 +150,47 @@ IGNORE_DISCONNECTED_MODULES:
 PDN_CORE_RING_VWIDTH: 15
 PDN_CORE_RING_HWIDTH: 15
 # Ensure minimum spacing for long metals
-FP_PDN_CORE_RING_VSPACING: 5
-FP_PDN_CORE_RING_HSPACING: 5
+PDN_CORE_RING_VSPACING: 5
+PDN_CORE_RING_HSPACING: 5
 
 PDN_CORE_RING_CONNECT_TO_PADS: True
 PDN_ENABLE_PINS: False
 
-# Due to OpenROAD bug
-# https://github.com/The-OpenROAD-Project/OpenROAD/issues/8229
-#PL_TIME_DRIVEN: False
-#PL_ROUTABILITY_DRIVEN: False
-
 # Because we have multiple power pads for one power domain
 MAGIC_EXT_UNIQUE: notopports
+
+MACROS:
+  RM_IHPSG13_1P_1024x32_c2_bm_bist:
+    gds:
+      - pdk_dir::libs.ref/sg13g2_sram/gds/RM_IHPSG13_1P_1024x32_c2_bm_bist.gds
+    lef:
+      - pdk_dir::libs.ref/sg13g2_sram/lef/RM_IHPSG13_1P_1024x32_c2_bm_bist.lef
+    vh:
+      - pdk_dir::libs.ref/sg13g2_sram/verilog/RM_IHPSG13_1P_1024x32_c2_bm_bist.v
+      - pdk_dir::libs.ref/sg13g2_sram/verilog/RM_IHPSG13_1P_core_behavioral_bm_bist.v
+    lib:
+      "nom_typ_1p20V_25C":
+        - pdk_dir::libs.ref/sg13g2_sram/lib/RM_IHPSG13_1P_1024x32_c2_bm_bist_typ_1p20V_25C.lib
+      "nom_fast_1p32V_m40C":
+        - pdk_dir::libs.ref/sg13g2_sram/lib/RM_IHPSG13_1P_1024x32_c2_bm_bist_fast_1p32V_m55C.lib
+      "nom_slow_1p08V_125C":
+        - pdk_dir::libs.ref/sg13g2_sram/lib/RM_IHPSG13_1P_1024x32_c2_bm_bist_slow_1p08V_125C.lib
+    instances:
+      # Make sure to specify the SRAMs in pdn_cfg.tcl
+      i_chip_core.sram_0:
+        location: [390, 390]
+        orientation: N
+      i_chip_core.sram_1:
+        location: [860, 390]
+        orientation: E
+
+# This is an alternative method compared to
+# specifying the power connections in the RTL
+PDN_MACRO_CONNECTIONS:
+- "i_chip_core.sram_0 VDD VSS VDDARRAY! VSS!"
+- "i_chip_core.sram_0 VDD VSS VDD! VSS!"
+- "i_chip_core.sram_1 VDD VSS VDDARRAY! VSS!"
+- "i_chip_core.sram_1 VDD VSS VDD! VSS!"
+
+# Custom PDN config to connect to SRAMs
+PDN_CFG: dir::pdn_cfg.tcl

--- a/librelane/pdn_cfg.tcl
+++ b/librelane/pdn_cfg.tcl
@@ -1,0 +1,231 @@
+# Copyright 2025 LibreLane Contributors
+#
+# Adapted from OpenLane
+#
+# Copyright 2020-2022 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
+source $::env(SCRIPTS_DIR)/openroad/common/set_global_connections.tcl
+set_global_connections
+
+set secondary []
+foreach vdd $::env(VDD_NETS) gnd $::env(GND_NETS) {
+    if { $vdd != $::env(VDD_NET)} {
+        lappend secondary $vdd
+
+        set db_net [[ord::get_db_block] findNet $vdd]
+        if {$db_net == "NULL"} {
+            set net [odb::dbNet_create [ord::get_db_block] $vdd]
+            $net setSpecial
+            $net setSigType "POWER"
+        }
+    }
+
+    if { $gnd != $::env(GND_NET)} {
+        lappend secondary $gnd
+
+        set db_net [[ord::get_db_block] findNet $gnd]
+        if {$db_net == "NULL"} {
+            set net [odb::dbNet_create [ord::get_db_block] $gnd]
+            $net setSpecial
+            $net setSigType "GROUND"
+        }
+    }
+}
+
+set_voltage_domain -name CORE -power $::env(VDD_NET) -ground $::env(GND_NET) \
+    -secondary_power $secondary
+
+
+
+if { $::env(PDN_MULTILAYER) == 1 } {
+
+    set arg_list [list]
+    if { $::env(PDN_ENABLE_PINS) } {
+        lappend arg_list -pins "$::env(PDN_VERTICAL_LAYER) $::env(PDN_HORIZONTAL_LAYER)"
+    }
+
+    define_pdn_grid \
+        -name stdcell_grid \
+        -starts_with POWER \
+        -voltage_domain CORE \
+        {*}$arg_list
+
+    set arg_list [list]
+    append_if_equals arg_list PDN_EXTEND_TO "core_ring" -extend_to_core_ring
+    append_if_equals arg_list PDN_EXTEND_TO "boundary" -extend_to_boundary
+
+    add_pdn_stripe \
+        -grid stdcell_grid \
+        -layer $::env(PDN_VERTICAL_LAYER) \
+        -width $::env(PDN_VWIDTH) \
+        -pitch $::env(PDN_VPITCH) \
+        -offset $::env(PDN_VOFFSET) \
+        -spacing $::env(PDN_VSPACING) \
+        -starts_with POWER \
+        {*}$arg_list
+
+    add_pdn_stripe \
+        -grid stdcell_grid \
+        -layer $::env(PDN_HORIZONTAL_LAYER) \
+        -width $::env(PDN_HWIDTH) \
+        -pitch $::env(PDN_HPITCH) \
+        -offset $::env(PDN_HOFFSET) \
+        -spacing $::env(PDN_HSPACING) \
+        -starts_with POWER \
+        {*}$arg_list
+
+    add_pdn_connect \
+        -grid stdcell_grid \
+        -layers "$::env(PDN_VERTICAL_LAYER) $::env(PDN_HORIZONTAL_LAYER)"
+} else {
+
+    set arg_list [list]
+    if { $::env(PDN_ENABLE_PINS) } {
+        lappend arg_list -pins "$::env(PDN_VERTICAL_LAYER)"
+    }
+
+    define_pdn_grid \
+        -name stdcell_grid \
+        -starts_with POWER \
+        -voltage_domain CORE \
+        {*}$arg_list
+
+    set arg_list [list]
+    append_if_equals arg_list PDN_EXTEND_TO "core_ring" -extend_to_core_ring
+    append_if_equals arg_list PDN_EXTEND_TO "boundary" -extend_to_boundary
+
+    add_pdn_stripe \
+        -grid stdcell_grid \
+        -layer $::env(PDN_VERTICAL_LAYER) \
+        -width $::env(PDN_VWIDTH) \
+        -pitch $::env(PDN_VPITCH) \
+        -offset $::env(PDN_VOFFSET) \
+        -spacing $::env(PDN_VSPACING) \
+        -starts_with POWER \
+        {*}$arg_list
+}
+
+# Adds the standard cell rails if enabled.
+if { $::env(PDN_ENABLE_RAILS) == 1 } {
+    add_pdn_stripe \
+        -grid stdcell_grid \
+        -layer $::env(PDN_RAIL_LAYER) \
+        -width $::env(PDN_RAIL_WIDTH) \
+        -followpins
+
+    add_pdn_connect \
+        -grid stdcell_grid \
+        -layers "$::env(PDN_RAIL_LAYER) $::env(PDN_VERTICAL_LAYER)"
+}
+
+
+# Adds the core ring if enabled.
+if { $::env(PDN_CORE_RING) == 1 } {
+    if { $::env(PDN_MULTILAYER) == 1 } {
+        set arg_list [list]
+        append_if_flag arg_list PDN_CORE_RING_ALLOW_OUT_OF_DIE -allow_out_of_die
+        append_if_flag arg_list PDN_CORE_RING_CONNECT_TO_PADS -connect_to_pads
+        append_if_equals arg_list PDN_EXTEND_TO "boundary" -extend_to_boundary
+
+        set pdn_core_vertical_layer $::env(PDN_VERTICAL_LAYER)
+        set pdn_core_horizontal_layer $::env(PDN_HORIZONTAL_LAYER)
+
+        if { [info exists ::env(PDN_CORE_VERTICAL_LAYER)] } {
+            set pdn_core_vertical_layer $::env(PDN_CORE_VERTICAL_LAYER)
+        }
+
+        if { [info exists ::env(PDN_CORE_HORIZONTAL_LAYER)] } {
+            set pdn_core_horizontal_layer $::env(PDN_CORE_HORIZONTAL_LAYER)
+        }
+
+        add_pdn_ring \
+            -grid stdcell_grid \
+            -layers "$pdn_core_vertical_layer $pdn_core_horizontal_layer" \
+            -widths "$::env(PDN_CORE_RING_VWIDTH) $::env(PDN_CORE_RING_HWIDTH)" \
+            -spacings "$::env(PDN_CORE_RING_VSPACING) $::env(PDN_CORE_RING_HSPACING)" \
+            -core_offset "$::env(PDN_CORE_RING_VOFFSET) $::env(PDN_CORE_RING_HOFFSET)" \
+            {*}$arg_list
+
+        if { [info exists ::env(PDN_CORE_VERTICAL_LAYER)] } {
+            add_pdn_connect \
+                -grid stdcell_grid \
+                -layers "$::env(PDN_CORE_VERTICAL_LAYER) $::env(PDN_HORIZONTAL_LAYER)"
+        }
+
+        if { [info exists ::env(PDN_CORE_HORIZONTAL_LAYER)] } {
+            add_pdn_connect \
+                -grid stdcell_grid \
+                -layers "$::env(PDN_CORE_HORIZONTAL_LAYER) $::env(PDN_VERTICAL_LAYER)"
+        }
+
+        if { [info exists ::env(PDN_CORE_VERTICAL_LAYER)] && [info exists ::env(PDN_CORE_HORIZONTAL_LAYER)] } {
+            add_pdn_connect \
+                -grid stdcell_grid \
+                -layers "$::env(PDN_CORE_VERTICAL_LAYER) $::env(PDN_CORE_HORIZONTAL_LAYER)"
+        }
+
+    } else {
+        throw APPLICATION "PDN_CORE_RING cannot be used when PDN_MULTILAYER is set to false."
+    }
+}
+
+define_pdn_grid \
+    -macro \
+    -default \
+    -name macro \
+    -starts_with POWER \
+    -halo "$::env(PDN_HORIZONTAL_HALO) $::env(PDN_VERTICAL_HALO)"
+
+add_pdn_connect \
+    -grid macro \
+    -layers "$::env(PDN_VERTICAL_LAYER) $::env(PDN_HORIZONTAL_LAYER)"
+
+# SRAM macros
+
+define_pdn_grid \
+    -macro \
+    -instances "\
+    i_chip_core.sram_0" \
+    -name sram_NS \
+    -starts_with POWER
+
+add_pdn_stripe \
+    -grid sram_NS \
+    -layer Metal5 \
+    -width 2.81 \
+    -pitch 11.24 \
+    -offset 2.81 \
+    -spacing 2.81 \
+    -nets "VSS VDD" \
+    -starts_with POWER
+
+add_pdn_connect \
+    -grid sram_NS \
+    -layers "Metal4 Metal5"
+add_pdn_connect \
+    -grid sram_NS \
+    -layers "Metal5 TopMetal1"
+
+define_pdn_grid \
+    -macro \
+    -instances "\
+    i_chip_core.sram_1" \
+    -name sram_WE \
+    -starts_with POWER
+
+add_pdn_connect \
+    -grid sram_WE \
+    -layers "Metal4 TopMetal1"

--- a/src/chip_core.sv
+++ b/src/chip_core.sv
@@ -38,8 +38,57 @@ module chip_core #(
         end
     end
     
-    assign bidir_out  = count;
     assign output_out = count;
+
+    logic [31:0] sram_0_out;
+
+    RM_IHPSG13_1P_1024x32_c2_bm_bist sram_0 (
+        .A_CLK  (clk),
+        .A_MEN  (1'b1),
+        .A_WEN  (1'b0),
+        .A_REN  (1'b1),
+        .A_ADDR ('0),
+        .A_DIN  ('0),
+        .A_DLY  (1'b1), // tie high!
+        .A_DOUT (sram_0_out),
+        .A_BM   ('0),
+        
+        // Built-in self test port
+        .A_BIST_CLK   ('0),
+        .A_BIST_EN    ('0),
+        .A_BIST_MEN   ('0),
+        .A_BIST_WEN   ('0),
+        .A_BIST_REN   ('0),
+        .A_BIST_ADDR  ('0),
+        .A_BIST_DIN   ('0),
+        .A_BIST_BM    ('0)
+    );
+
+    logic [31:0] sram_1_out;
+
+    RM_IHPSG13_1P_1024x32_c2_bm_bist sram_1 (
+        .A_CLK  (clk),
+        .A_MEN  (1'b1),
+        .A_WEN  (1'b0),
+        .A_REN  (1'b1),
+        .A_ADDR ('0),
+        .A_DIN  ('0),
+        .A_DLY  (1'b1), // tie high!
+        .A_DOUT (sram_1_out),
+        .A_BM   ('0),
+        
+        // Built-in self test port
+        .A_BIST_CLK   ('0),
+        .A_BIST_EN    ('0),
+        .A_BIST_MEN   ('0),
+        .A_BIST_WEN   ('0),
+        .A_BIST_REN   ('0),
+        .A_BIST_ADDR  ('0),
+        .A_BIST_DIN   ('0),
+        .A_BIST_BM    ('0)
+    );
+
+    assign bidir_out = {7'b0, (^sram_0_out) ^ (^sram_1_out)};
 
 endmodule
 


### PR DESCRIPTION
This PR adds two SRAM instances in north and east orientation to the example design.
The antenna check has been enabled by default (thanks to a PDK update).
`SLANG_ARGUMENTS` has been added with a default value to allow for inout ports in the design.